### PR TITLE
Renombrado de interfaces

### DIFF
--- a/SGE.Aplicacion/CasosDeUso/ExpedienteAltaCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteAltaCasoDeUso.cs
@@ -8,7 +8,7 @@ using SGE.Aplicacion.Interfaces.Validadores;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class ExpedienteAltaCasoDeUso(
-    IExpedienteRepositorio expedienteRepositorio,
+    IRepositorioExpediente repositorioExpediente,
     IExpedienteValidador   expedienteValidador,
     IServicioAutorizacion  servicioAutorizacion
 )
@@ -26,7 +26,7 @@ public class ExpedienteAltaCasoDeUso(
         }
 
         expediente.IdUsuarioUltimaModificacion = usuario.Id;
-        expedienteRepositorio.Alta(expediente);
+        repositorioExpediente.Alta(expediente);
     }
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteBajaCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteBajaCasoDeUso.cs
@@ -7,8 +7,8 @@ using SGE.Aplicacion.Interfaces.Servicios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class ExpedienteBajaCasoDeUso(
-    IExpedienteRepositorio expedienteRepositorio,
-    ITramiteRepositorio    tramiteRepositorio,
+    IRepositorioExpediente repositorioExpediente,
+    IRepositorioTramite    repositorioTramite,
     IServicioAutorizacion  servicioAutorizacion
 )
 {
@@ -19,8 +19,8 @@ public class ExpedienteBajaCasoDeUso(
             throw new AutorizacionException("El usuario no tiene permisos para dar de baja un expediente.");
         }
 
-        expedienteRepositorio.Baja(idExpediente);
-        tramiteRepositorio.BajaPorExpediente(idExpediente);
+        repositorioExpediente.Baja(idExpediente);
+        repositorioTramite.BajaPorExpediente(idExpediente);
     }
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteBuscarPorIdCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteBuscarPorIdCasoDeUso.cs
@@ -3,9 +3,9 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Aplicacion.CasosDeUso;
 
-public class ExpedienteBuscarPorIdCasoDeUso(IExpedienteRepositorio expedienteRepositorio)
+public class ExpedienteBuscarPorIdCasoDeUso(IRepositorioExpediente repositorioExpediente)
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
-    public Expediente? Ejecutar(int idExpediente) => expedienteRepositorio.BuscarPorId(idExpediente);
+    public Expediente? Ejecutar(int idExpediente) => repositorioExpediente.BuscarPorId(idExpediente);
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteBuscarPorIdConTramitesCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteBuscarPorIdConTramitesCasoDeUso.cs
@@ -4,17 +4,17 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class ExpedienteBuscarPorIdConTramitesCasoDeUso(
-    IExpedienteRepositorio expedienteRepositorio,
-    ITramiteRepositorio    tramiteRepositorio
+    IRepositorioExpediente repositorioExpediente,
+    IRepositorioTramite    repositorioTramite
 )
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     public Expediente? Ejecutar(int idExpediente)
     {
-        Expediente? expediente = expedienteRepositorio.BuscarPorId(idExpediente);
+        Expediente? expediente = repositorioExpediente.BuscarPorId(idExpediente);
 
         if (expediente != null) {
-//            expediente = tramiteRepositorio.ObtenerTramitesPorExpediente(expediente);
+//            expediente = repositorioTramite.ObtenerTramitesPorExpediente(expediente);
         }
 
         return expediente;

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteListarCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteListarCasoDeUso.cs
@@ -3,9 +3,9 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Aplicacion.CasosDeUso;
 
-public class ExpedienteListarCasoDeUso(IExpedienteRepositorio expedienteRepositorio)
+public class ExpedienteListarCasoDeUso(IRepositorioExpediente repositorioExpediente)
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
-    public List<Expediente> Ejecutar() => expedienteRepositorio.Listar();
+    public List<Expediente> Ejecutar() => repositorioExpediente.Listar();
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteListarConTramitesCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteListarConTramitesCasoDeUso.cs
@@ -4,18 +4,18 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class ExpedienteListarConTramitesCasoDeUso(
-    IExpedienteRepositorio expedienteRepositorio,
-    ITramiteRepositorio    tramiteRepositorio
+    IRepositorioExpediente repositorioExpediente,
+    IRepositorioTramite    repositorioTramite
 )
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     public List<Expediente> Ejecutar()
     {
-        List<Expediente> expedientes            = expedienteRepositorio.Listar();
+        List<Expediente> expedientes            = repositorioExpediente.Listar();
         List<Expediente> expedientesConTramites = [];
 
         foreach (Expediente t in expedientes) {
-            expedientesConTramites.Add(tramiteRepositorio.ObtenerTramitesPorExpediente(t));
+            expedientesConTramites.Add(repositorioTramite.ObtenerTramitesPorExpediente(t));
         }
 
         return expedientesConTramites;

--- a/SGE.Aplicacion/CasosDeUso/ExpedienteModificarCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/ExpedienteModificarCasoDeUso.cs
@@ -8,7 +8,7 @@ using SGE.Aplicacion.Interfaces.Validadores;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class ExpedienteModificarCasoDeUso(
-    IExpedienteRepositorio expedienteRepositorio,
+    IRepositorioExpediente repositorioExpediente,
     IExpedienteValidador   expedienteValidador,
     IServicioAutorizacion  servicioAutorizacion
 )
@@ -25,7 +25,7 @@ public class ExpedienteModificarCasoDeUso(
         }
 
         expediente.IdUsuarioUltimaModificacion = usuario.Id;
-        expedienteRepositorio.Modificar(expediente);
+        repositorioExpediente.Modificar(expediente);
     }
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/TramiteAltaCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/TramiteAltaCasoDeUso.cs
@@ -9,7 +9,7 @@ using SGE.Aplicacion.Servicios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class TramiteAltaCasoDeUso(
-    ITramiteRepositorio         tramiteRepositorio,
+    IRepositorioTramite         repositorioTramite,
     ITramiteValidador           tramiteValidador,
     IServicioAutorizacion       servicioAutorizacion,
     ServicioActualizacionEstado servicioActualizacionEstado
@@ -28,7 +28,7 @@ public class TramiteAltaCasoDeUso(
 
         tramite.IdUsuarioUltimaModificacion = usuario.Id;
 
-        tramiteRepositorio.Alta(tramite);
+        repositorioTramite.Alta(tramite);
         servicioActualizacionEstado.ActualizarEstado(tramite);
     }
     #endregion

--- a/SGE.Aplicacion/CasosDeUso/TramiteBajaCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/TramiteBajaCasoDeUso.cs
@@ -8,7 +8,7 @@ using SGE.Aplicacion.Servicios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class TramiteBajaCasoDeUso(
-    ITramiteRepositorio         tramiteRepositorio,
+    IRepositorioTramite         repositorioTramite,
     ServicioActualizacionEstado servicioActualizacionEstado,
     IServicioAutorizacion       servicioAutorizacion
 )
@@ -20,7 +20,7 @@ public class TramiteBajaCasoDeUso(
             throw new AutorizacionException("El usuario no tiene permisos para realizar esta acción.");
         }
 
-        tramiteRepositorio.Baja(idTramite);
+        repositorioTramite.Baja(idTramite);
         servicioActualizacionEstado.ActualizarEstado(idTramite);
     }
     #endregion

--- a/SGE.Aplicacion/CasosDeUso/TramiteConsultaPorEtiquetaCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/TramiteConsultaPorEtiquetaCasoDeUso.cs
@@ -4,10 +4,10 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Aplicacion.CasosDeUso;
 
-public class TramiteConsultaPorEtiquetaCasoDeUso(ITramiteRepositorio tramiteRepositorio)
+public class TramiteConsultaPorEtiquetaCasoDeUso(IRepositorioTramite repositorioTramite)
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     public List<Tramite> Ejecutar(EtiquetaTramite etiquetaTramite)
-        => tramiteRepositorio.ObtenerPorEtiqueta(etiquetaTramite);
+        => repositorioTramite.ObtenerPorEtiqueta(etiquetaTramite);
     #endregion
 }

--- a/SGE.Aplicacion/CasosDeUso/TramiteModificacionCasoDeUso.cs
+++ b/SGE.Aplicacion/CasosDeUso/TramiteModificacionCasoDeUso.cs
@@ -9,7 +9,7 @@ using SGE.Aplicacion.Servicios;
 namespace SGE.Aplicacion.CasosDeUso;
 
 public class TramiteModificacionCasoDeUso(
-    ITramiteRepositorio         repositorioTramite,
+    IRepositorioTramite         repositorioTramite,
     ITramiteValidador           tramiteValidador,
     ServicioActualizacionEstado servicioActualizacionEstado,
     IServicioAutorizacion       servicioAutorizacion

--- a/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioExpediente.cs
+++ b/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioExpediente.cs
@@ -7,7 +7,7 @@ namespace SGE.Aplicacion.Interfaces.Repositorios;
 /// <summary>
 ///     Interfaz para cualquier clase que implemente un repositorio de expedientes.
 /// </summary>
-public interface IExpedienteRepositorio
+public interface IRepositorioExpediente
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     /// <summary>

--- a/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioPermiso.cs
+++ b/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioPermiso.cs
@@ -2,7 +2,7 @@
 
 namespace SGE.Aplicacion.Interfaces.Repositorios;
 
-public interface IPermisoRepositorio
+public interface IRepositorioPermiso
 {
     public void Agregar(Permiso permiso);
     

--- a/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioTramite.cs
+++ b/SGE.Aplicacion/Interfaces/Repositorios/IRepositorioTramite.cs
@@ -4,7 +4,7 @@ using SGE.Aplicacion.Excepciones;
 
 namespace SGE.Aplicacion.Interfaces.Repositorios;
 
-public interface ITramiteRepositorio
+public interface IRepositorioTramite
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     /// <summary>

--- a/SGE.Aplicacion/Servicios/EspecificacionCambioEstado.cs
+++ b/SGE.Aplicacion/Servicios/EspecificacionCambioEstado.cs
@@ -7,8 +7,8 @@ namespace SGE.Aplicacion.Servicios;
 /// <summary>
 ///     Clase que define la especificación para el cambio de estado de un expediente.
 /// </summary>
-/// <param name="tramiteRepositorio">Repositorio de trámites.</param>
-public class EspecificacionCambioEstado(ITramiteRepositorio tramiteRepositorio)
+/// <param name="repositorioTramite">Repositorio de trámites.</param>
+public class EspecificacionCambioEstado(IRepositorioTramite repositorioTramite)
 {
     #region METODOS PUBLICOS ---------------------------------------------------------------------------
     /// <summary>
@@ -18,7 +18,7 @@ public class EspecificacionCambioEstado(ITramiteRepositorio tramiteRepositorio)
     /// <returns><see cref="EstadoExpediente" /> que corresponde al expediente.</returns>
     public EstadoExpediente? DefinirEstado(int idExpediente)
     {
-        Tramite? tramite = tramiteRepositorio.ObtenerUltimoPorExpediente(idExpediente);
+        Tramite? tramite = repositorioTramite.ObtenerUltimoPorExpediente(idExpediente);
 
         return tramite is null ? null : DefinirEstado(tramite);
     }

--- a/SGE.Aplicacion/Servicios/ServicioActualizacionEstado.cs
+++ b/SGE.Aplicacion/Servicios/ServicioActualizacionEstado.cs
@@ -9,13 +9,13 @@ namespace SGE.Aplicacion.Servicios;
 ///     utilizar una clase que implemente la interfaz <see cref="EspecificacionCambioEstado" />
 ///     para determinar el nuevo estado del expediente, y en base a eso, actualizarlo.
 /// </summary>
-/// <param name="expedienteRepositorio">Repositorio de expedientes.</param>
+/// <param name="repositorioExpediente">Repositorio de expedientes.</param>
 /// <param name="especificacionCambioEstado">
 ///     Servicio para determinar el nuevo
 ///     estado del expediente.
 /// </param>
 public class ServicioActualizacionEstado(
-    IExpedienteRepositorio     expedienteRepositorio,
+    IRepositorioExpediente     repositorioExpediente,
     EspecificacionCambioEstado especificacionCambioEstado
 )
 {
@@ -32,7 +32,7 @@ public class ServicioActualizacionEstado(
             return;
         }
 
-        expedienteRepositorio.ActualizarEstado(idExpediente, estado.Value);
+        repositorioExpediente.ActualizarEstado(idExpediente, estado.Value);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public class ServicioActualizacionEstado(
             return;
         }
 
-        expedienteRepositorio.ActualizarEstado(tramite.ExpedienteId ?? 0, estado.Value);
+        repositorioExpediente.ActualizarEstado(tramite.ExpedienteId ?? 0, estado.Value);
     }
     #endregion
 }

--- a/SGE.Consola/Program.cs
+++ b/SGE.Consola/Program.cs
@@ -29,25 +29,25 @@ public class Program
 
         IExpedienteValidador       expedienteValidador        = new ExpedienteValidador();
         ITramiteValidador          tramiteValidador           = new TramiteValidador();
-        IExpedienteRepositorio     expedienteRepositorio      = new RepositorioExpedienteSqlite(context);
-        ITramiteRepositorio        tramiteRepositorio         = new RepositorioTramiteSqlite(context);
+        IRepositorioExpediente     repositorioExpediente      = new RepositorioExpedienteSqlite(context);
+        IRepositorioTramite        repositorioTramite         = new RepositorioTramiteSqlite(context);
         IServicioAutorizacion      servicioAutorizacion       = new ServicioAutorizacionProvisorio();
-        EspecificacionCambioEstado especificacionCambioEstado = new(tramiteRepositorio);
+        EspecificacionCambioEstado especificacionCambioEstado = new(repositorioTramite);
 
         ServicioActualizacionEstado servicioActualizacionEstado =
-            new(expedienteRepositorio, especificacionCambioEstado);
+            new(repositorioExpediente, especificacionCambioEstado);
 
         ExpedienteAltaCasoDeUso expedienteAltaCasoDeUso =
-            new(expedienteRepositorio, expedienteValidador, servicioAutorizacion);
+            new(repositorioExpediente, expedienteValidador, servicioAutorizacion);
 
         TramiteAltaCasoDeUso tramiteAltaCasoDeUso =
-            new(tramiteRepositorio, tramiteValidador, servicioAutorizacion, servicioActualizacionEstado);
+            new(repositorioTramite, tramiteValidador, servicioAutorizacion, servicioActualizacionEstado);
 
         TramiteModificacionCasoDeUso tramiteModificacionCasoDeUso =
-            new(tramiteRepositorio, tramiteValidador, servicioActualizacionEstado, servicioAutorizacion);
+            new(repositorioTramite, tramiteValidador, servicioActualizacionEstado, servicioAutorizacion);
 
         TramiteConsultaPorEtiquetaCasoDeUso tramiteConsultaPorEtiquetaCasoDeUso =
-            new(tramiteRepositorio);
+            new(repositorioTramite);
 
         Expediente expediente = new() { Caratula = "Carátula de prueba del expediente" };
 

--- a/SGE.Repositorios/RepositorioExpedienteSqlite.cs
+++ b/SGE.Repositorios/RepositorioExpedienteSqlite.cs
@@ -5,7 +5,7 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Repositorios;
 
-public class RepositorioExpedienteSqlite(SgeContext context) : RepositorioSqlite(context), IExpedienteRepositorio
+public class RepositorioExpedienteSqlite(SgeContext context) : RepositorioSqlite(context), IRepositorioExpediente
 {
     public void ActualizarEstado(int idExpediente, EstadoExpediente estadoExpediente)
     {

--- a/SGE.Repositorios/RepositorioPermisoSqlite.cs
+++ b/SGE.Repositorios/RepositorioPermisoSqlite.cs
@@ -5,7 +5,7 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Repositorios;
 
-internal class RepositorioPermisoSqlite(SgeContext context) : RepositorioSqlite(context), IPermisoRepositorio
+internal class RepositorioPermisoSqlite(SgeContext context) : RepositorioSqlite(context), IRepositorioPermiso
 {
     public void Agregar(Permiso permiso)
     {

--- a/SGE.Repositorios/RepositorioTramiteSqlite.cs
+++ b/SGE.Repositorios/RepositorioTramiteSqlite.cs
@@ -6,7 +6,7 @@ using SGE.Aplicacion.Interfaces.Repositorios;
 
 namespace SGE.Repositorios;
 
-public class RepositorioTramiteSqlite(SgeContext context) : RepositorioSqlite(context), ITramiteRepositorio
+public class RepositorioTramiteSqlite(SgeContext context) : RepositorioSqlite(context), IRepositorioTramite
 {
     public void Alta(Tramite tramite)
     {


### PR DESCRIPTION
Se renombraron las interfaces para que coincidan con el tipo de nombramiento que se está dando a los repositorios.